### PR TITLE
feat: add only_actions field in events-section.

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -8,6 +8,7 @@ spark_locals_without_parens = [
   current_action_versions: 1,
   event_log: 1,
   ignore_actions: 1,
+  only_actions: 1,
   persist_actor_primary_key: 2,
   persist_actor_primary_key: 3,
   primary_key_type: 1,

--- a/documentation/dsls/DSL-AshEvents.Events.md
+++ b/documentation/dsls/DSL-AshEvents.Events.md
@@ -21,6 +21,15 @@ end
 
 ```
 
+```
+events do
+  event_log MyApp.Events.EventLog
+  only_actions [:create, :update, :destroy]
+  current_action_versions create: 2, update: 3, destroy: 2
+end
+
+```
+
 
 
 
@@ -29,6 +38,7 @@ end
 | Name | Type | Default | Docs |
 |------|------|---------|------|
 | [`event_log`](#events-event_log){: #events-event_log .spark-required} | `module` |  | The event-log resource that creates and stores events. |
+| [`only_actions`](#events-only_actions){: #events-only_actions } | `list(atom)` |  | A list of actions that should be the only actions that have events created when run. |
 | [`ignore_actions`](#events-ignore_actions){: #events-ignore_actions } | `list(atom)` | `[]` | A list of actions that should not have events created when run. |
 | [`current_action_versions`](#events-current_action_versions){: #events-current_action_versions } | `keyword` | `[]` | A keyword list of action versions. This will be used to set the version in the created events when the actions are run. Version will default to 1 for all actions that are not listed here. |
 

--- a/lib/events/events.ex
+++ b/lib/events/events.ex
@@ -11,6 +11,13 @@ defmodule AshEvents.Events do
         ignore_actions [:create_old_v1, :update_old_v1, :update_old_v2, :destroy_old_v1]
         current_action_versions create: 2, update: 3, destroy: 2
       end
+      """,
+      """
+      events do
+        event_log MyApp.Events.EventLog
+        only_actions [:create, :update, :destroy]
+        current_action_versions create: 2, update: 3, destroy: 2
+      end
       """
     ],
     schema: [
@@ -18,6 +25,11 @@ defmodule AshEvents.Events do
         type: {:behaviour, AshEvents.EventLog},
         required: true,
         doc: "The event-log resource that creates and stores events."
+      ],
+      only_actions: [
+        type: {:list, :atom},
+        doc:
+          "A list of actions that should be the only actions that have events created when run."
       ],
       ignore_actions: [
         type: {:list, :atom},

--- a/test/ash_events_test.exs
+++ b/test/ash_events_test.exs
@@ -1,4 +1,5 @@
 defmodule AshEventsTest do
+  alias AshEvents.Test.Accounts.OrgDetails
   alias AshEvents.Test.Events.EventLogUuidV7
   alias AshEvents.Test.Events.SystemActor
   use AshEvents.RepoCase, async: false
@@ -518,5 +519,12 @@ defmodule AshEventsTest do
 
     assert Enum.count(rows) == 2
     assert lock_row != nil
+  end
+
+  test "only_actions works as expected" do
+    action_names = Ash.Resource.Info.actions(OrgDetails) |> Enum.map(& &1.name)
+    assert :create_ash_events_orig_impl in action_names
+    assert :update_ash_events_orig_impl in action_names
+    assert :create_not_in_only_ash_events_orig_impl not in action_names
   end
 end

--- a/test/support/accounts/org_details.ex
+++ b/test/support/accounts/org_details.ex
@@ -12,12 +12,17 @@ defmodule AshEvents.Test.Accounts.OrgDetails do
 
   events do
     event_log AshEvents.Test.Events.EventLog
+    only_actions([:create, :update])
   end
 
   actions do
     defaults [:read]
 
     create :create do
+      accept [:id, :created_at, :updated_at, :details]
+    end
+
+    create :create_not_in_only do
       accept [:id, :created_at, :updated_at, :details]
     end
 


### PR DESCRIPTION
Adds `only_actions`, which can be used instead of `ignore_actions` in the events-section of a resource.

Fixes https://github.com/ash-project/ash_events/issues/19

### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
