### PR TITLE
fix: try converting value to existing atom before dumping.

### DIFF
--- a/lib/events/action_wrapper_helpers.ex
+++ b/lib/events/action_wrapper_helpers.ex
@@ -16,6 +16,11 @@ defmodule AshEvents.Events.ActionWrapperHelpers do
   end
 
   def dump_value(value, attribute) do
+    value =
+      if attribute.type == Ash.Type.Atom and is_binary(value),
+        do: String.to_existing_atom(value),
+        else: value
+
     {:ok, dumped_value} = Ash.Type.dump_to_embedded(attribute.type, value, attribute.constraints)
     dumped_value
   end


### PR DESCRIPTION
Ensure atom attributes are converted to existing atoms before calling Ash.Type.dump_to_embedded.

When the passed value is a string, this caused an error due to the one_of constraints check failing.
