### PR TITLE
Support soft destroy actions

### DIFF
--- a/lib/events/destroy_action_wrapper.ex
+++ b/lib/events/destroy_action_wrapper.ex
@@ -33,4 +33,7 @@ defmodule AshEvents.DestroyActionWrapper do
       {:ok, changeset.data}
     end
   end
+
+  def update(changeset, module_opts, ctx),
+    do: AshEvents.UpdateActionWrapper.update(changeset, module_opts, ctx)
 end


### PR DESCRIPTION
Define ` AshEvents.DestroyActionWrapper.update\3` by redirecting to `AshEvents.UpdateActionWrapper.update\3`. This enables support for soft destroy, which currently throws `UndefinedFunctionError`.

Probably should have a test and review before being merged, this was a quick addition but it's working as expected for what I was working on and correctly records the action type as `:destroy`.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
