### PR TITLE
add support for soft destroy

### DIFF
--- a/lib/events/destroy_action_wrapper.ex
+++ b/lib/events/destroy_action_wrapper.ex
@@ -8,6 +8,8 @@ defmodule AshEvents.DestroyActionWrapper do
   """
   use Ash.Resource.ManualDestroy
 
+  defdelegate update(changeset, module_opts, ctx), to: AshEvents.UpdateActionWrapper
+
   def destroy(changeset, module_opts, ctx) do
     merged_ctx = Map.get(ctx, :source_context) |> Map.merge(ctx)
 

--- a/priv/test_repo/migrations/20260130000001_add_soft_deletable_users.exs
+++ b/priv/test_repo/migrations/20260130000001_add_soft_deletable_users.exs
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2023 ash_events contributors <https://github.com/ash-project/ash_events/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshEvents.TestRepo.Migrations.AddSoftDeletableUsers do
+  @moduledoc """
+  Adds the soft_deletable_users table for testing soft delete functionality.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    create table(:soft_deletable_users, primary_key: false) do
+      add(:id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true)
+
+      add(:created_at, :utc_datetime_usec,
+        null: false,
+        default: fragment("(now() AT TIME ZONE 'utc')")
+      )
+
+      add(:updated_at, :utc_datetime_usec,
+        null: false,
+        default: fragment("(now() AT TIME ZONE 'utc')")
+      )
+
+      add(:email, :text, null: false)
+      add(:name, :text)
+      add(:archived_at, :utc_datetime_usec)
+    end
+
+    create unique_index(:soft_deletable_users, [:email], name: "soft_deletable_users_unique_email_index")
+  end
+
+  def down do
+    drop_if_exists(unique_index(:soft_deletable_users, [:email], name: "soft_deletable_users_unique_email_index"))
+    drop(table(:soft_deletable_users))
+  end
+end

--- a/test/ash_events/soft_delete_test.exs
+++ b/test/ash_events/soft_delete_test.exs
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2023 ash_events contributors <https://github.com/ash-project/ash_events/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshEvents.SoftDeleteTest do
+  use AshEvents.RepoCase, async: false
+
+  alias AshEvents.Accounts.SoftDeletableUser
+  alias AshEvents.EventLogs.EventLog
+  alias AshEvents.EventLogs.SystemActor
+
+  require Ash.Query
+
+  @actor %SystemActor{name: "test_runner"}
+
+  describe "soft delete" do
+    test "soft delete creates event with action_type :destroy" do
+      # Create a user
+      user =
+        SoftDeletableUser
+        |> Ash.Changeset.for_create(:create, %{
+          email: "test@example.com",
+          name: "Test User"
+        })
+        |> Ash.create!(actor: @actor)
+
+      # Soft delete the user
+      user
+      |> Ash.Changeset.for_destroy(:archive, %{}, actor: @actor)
+      |> Ash.destroy!()
+
+      # Check that an event was created with action_type :destroy
+      events =
+        EventLog
+        |> Ash.Query.filter(resource == ^SoftDeletableUser)
+        |> Ash.Query.sort({:id, :asc})
+        |> Ash.read!()
+
+      assert length(events) == 2
+
+      [create_event, destroy_event] = events
+
+      assert create_event.action == :create
+      assert create_event.action_type == :create
+
+      assert destroy_event.action == :archive
+      assert destroy_event.action_type == :destroy
+    end
+  end
+end

--- a/test/support/accounts/domain.ex
+++ b/test/support/accounts/domain.ex
@@ -74,5 +74,10 @@ defmodule AshEvents.Accounts do
       define :mark_upload_uploaded, action: :mark_uploaded
       define :mark_upload_skipped, action: :mark_skipped
     end
+
+    resource AshEvents.Accounts.SoftDeletableUser do
+      define :create_soft_deletable_user, action: :create
+      define :archive_soft_deletable_user, action: :archive
+    end
   end
 end

--- a/test/support/accounts/soft_deletable_user.ex
+++ b/test/support/accounts/soft_deletable_user.ex
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2023 ash_events contributors <https://github.com/ash-project/ash_events/graphs.contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshEvents.Accounts.SoftDeletableUser do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshEvents.Accounts,
+    data_layer: AshPostgres.DataLayer,
+    extensions: [AshEvents.Events]
+
+  postgres do
+    table "soft_deletable_users"
+    repo AshEvents.TestRepo
+  end
+
+  events do
+    event_log AshEvents.EventLogs.EventLog
+    create_timestamp :created_at
+    update_timestamp :updated_at
+  end
+
+  actions do
+    defaults [:read]
+
+    create :create do
+      accept [:id, :email, :name, :created_at, :updated_at, :archived_at]
+    end
+
+    update :update do
+      require_atomic? false
+      accept [:name]
+    end
+
+    destroy :archive do
+      require_atomic? false
+      soft? true
+      change set_attribute(:archived_at, &DateTime.utc_now/0)
+    end
+
+    read :get_by_id do
+      get_by [:id]
+    end
+  end
+
+  attributes do
+    uuid_primary_key :id do
+      writable? true
+    end
+
+    create_timestamp :created_at do
+      public? true
+      allow_nil? false
+      writable? true
+    end
+
+    update_timestamp :updated_at do
+      public? true
+      allow_nil? false
+      writable? true
+    end
+
+    attribute :email, :string do
+      public? true
+      allow_nil? false
+    end
+
+    attribute :name, :string do
+      public? true
+      allow_nil? true
+    end
+
+    attribute :archived_at, :utc_datetime_usec do
+      public? true
+      allow_nil? true
+      writable? true
+    end
+  end
+
+  identities do
+    identity :unique_email, [:email]
+  end
+end

--- a/test/support/event_logs/clear_records.ex
+++ b/test/support/event_logs/clear_records.ex
@@ -13,6 +13,7 @@ defmodule AshEvents.EventLogs.ClearRecords do
     {_, nil} = TestRepo.delete_all("routed_users")
     {_, nil} = TestRepo.delete_all("users_embedded")
     {_, nil} = TestRepo.delete_all("users_with_auto_attrs")
+    {_, nil} = TestRepo.delete_all("soft_deletable_users")
     :ok
   end
 end


### PR DESCRIPTION
Implements the delegation suggested from Zach in Issue #78 

PR #69  does the same but not with delegate and no tests

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
