### PR TITLE
chore: move preferred_cli_env from project to cli (elixir 1.19 warning)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,6 +25,14 @@ defmodule AshEvents.MixProject do
       description: @description,
       source_url: "https://github.com/ash-project/ash_events",
       homepage_url: "https://github.com/ash-project/ash_events",
+      dialyzer: [
+        plt_add_apps: [:mix]
+      ]
+    ]
+  end
+
+  def cli do
+    [
       preferred_cli_env: [
         "test.create": :test,
         "test.migrate": :test,
@@ -35,9 +43,6 @@ defmodule AshEvents.MixProject do
         "test.generate_migrations": :test,
         "test.reset": :test,
         tidewave: :test
-      ],
-      dialyzer: [
-        plt_add_apps: [:mix]
       ]
     ]
   end


### PR DESCRIPTION
solve the warning in elixir 1.19

warning: setting :preferred_cli_env in your mix.exs "def project" is deprecated, set it inside "def cli" instead

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
