### PR TITLE
fix: preserve manage_relationship changes for AshPhoenix nested forms

### DIFF
--- a/lib/events/transformers/wrap_actions.ex
+++ b/lib/events/transformers/wrap_actions.ex
@@ -144,6 +144,22 @@ defmodule AshEvents.Events.Transformers.WrapActions do
           end
         end)
 
+      # Copy manage_relationship changes with ignore?: true so that AshPhoenix
+      # can detect them for nested form generation. The actual relationship
+      # management is handled by the wrapped version above.
+      ignored_manage_relationship_changes =
+        action.changes
+        |> Enum.filter(fn
+          %Ash.Resource.Change{change: {Ash.Resource.Change.ManageRelationship, _}} -> true
+          _ -> false
+        end)
+        |> Enum.map(fn %Ash.Resource.Change{change: {mod, opts}} = change ->
+          updated_opts =
+            Keyword.update(opts, :opts, [ignore?: true], &Keyword.put(&1, :ignore?, true))
+
+          %{change | change: {mod, updated_opts}}
+        end)
+
       manual_module =
         case action.type do
           :create -> AshEvents.CreateActionWrapper
@@ -167,7 +183,8 @@ defmodule AshEvents.Events.Transformers.WrapActions do
             arguments: action.arguments,
             changes:
               [store_changeset_params, apply_replay_primary_key | wrapped_changes] ++
-                [apply_changed_attributes]
+                [apply_changed_attributes] ++
+                ignored_manage_relationship_changes
         }
         |> then(fn action ->
           case action.type do

--- a/test/ash_events/manage_relationship_forms_test.exs
+++ b/test/ash_events/manage_relationship_forms_test.exs
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2023 ash_events contributors <https://github.com/ash-project/ash_events/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshEvents.ManageRelationshipFormsTest do
+  use ExUnit.Case, async: true
+
+  # Regression test for https://github.com/ash-project/ash_events/issues/87
+  # AshPhoenix.Form.Auto needs to detect manage_relationship changes on actions
+  # wrapped by AshEvents, so that nested forms (inputs_for) work correctly.
+
+  test "AshPhoenix auto forms detect manage_relationship on AshEvents-wrapped actions" do
+    auto_forms = AshPhoenix.Form.Auto.auto(AshEvents.Accounts.User, :create_with_roles)
+
+    assert Keyword.has_key?(auto_forms, :user_role),
+           "Expected auto forms to include :user_role, got: #{inspect(Keyword.keys(auto_forms))}"
+  end
+
+  test "AshPhoenix.Form.for_create works with forms: [auto?: true] on wrapped actions" do
+    form =
+      AshPhoenix.Form.for_create(AshEvents.Accounts.User, :create_with_roles,
+        forms: [auto?: true]
+      )
+
+    assert Keyword.has_key?(form.form_keys, :user_role),
+           "Expected :user_role in form_keys, got: #{inspect(Keyword.keys(form.form_keys))}"
+  end
+end

--- a/test/support/accounts/user.ex
+++ b/test/support/accounts/user.ex
@@ -97,6 +97,14 @@ defmodule AshEvents.Accounts.User do
       change set_attribute(:confirmed_at, &DateTime.utc_now/0)
     end
 
+    create :create_with_roles do
+      accept [:id, :created_at, :updated_at, :email, :given_name, :family_name, :hashed_password]
+      argument :user_role, :map
+
+      change manage_relationship(:user_role, type: :direct_control)
+      change set_attribute(:confirmed_at, &DateTime.utc_now/0)
+    end
+
     update :update do
       require_atomic? false
       accept [:given_name, :family_name, :created_at, :updated_at, :hashed_password]


### PR DESCRIPTION
**Issue:** I was having an issue using AshPhoenix auto forms with AshEvent, and tracked down the issue to the way AshEvent wrap actions, hiding relationship changes from AshPhoenix. Raising `AshPhoenix.Form.NoFormConfigured` when trying to access a nested form.  

**Solution:** As suggested by @zachdaniel in #87, I updated [lib/events/transformers/wrap_actions.ex](https://github.com/BlitzBanana/ash_events/commit/3710d5bb8639ff2a02bacbcbc71b94a881dca2f6#diff-cd55ecf38c116c1938b47fe1ea0428775ce163bb10dcc9944ccee41a42dda3a5) to append a copy of relationship changes to the wrapper itself, but with the `ignore?: true` option. So AshPhoenix can detect them, but the actual execution stays in the wrapped original action.

I took the liberty to add a unit test for this specific issue.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
