### PR TITLE
fix: handle nil original_params in bulk destroy with nested operations

### DIFF
--- a/lib/events/destroy_action_wrapper.ex
+++ b/lib/events/destroy_action_wrapper.ex
@@ -30,9 +30,13 @@ defmodule AshEvents.DestroyActionWrapper do
         |> Ash.Context.to_opts()
         |> Keyword.put(:return_notifications?, ctx.return_notifications? || false)
 
+      original_params =
+        Map.get(merged_ctx, :original_params) ||
+          Map.get(changeset.context, :original_params, %{})
+
       AshEvents.Events.ActionWrapperHelpers.create_event!(
         changeset,
-        merged_ctx.original_params,
+        original_params,
         DateTime.utc_now(),
         module_opts,
         opts
@@ -90,9 +94,13 @@ defmodule AshEvents.DestroyActionWrapper do
         |> Keyword.put(:return_destroyed?, true)
         |> Keyword.put(:return_notifications?, ctx.return_notifications? || false)
 
+      original_params =
+        Map.get(merged_ctx, :original_params) ||
+          Map.get(changeset.context, :original_params, %{})
+
       AshEvents.Events.ActionWrapperHelpers.create_event!(
         changeset,
-        merged_ctx.original_params,
+        original_params,
         DateTime.utc_now(),
         module_opts,
         opts

--- a/test/ash_events/bulk_actions_test.exs
+++ b/test/ash_events/bulk_actions_test.exs
@@ -278,6 +278,70 @@ defmodule AshEvents.BulkActionsTest do
     assert Enum.count(events) == 3
   end
 
+  test "bulk_destroy with soft delete and nested bulk operation works correctly" do
+    alias AshEvents.Accounts.Article
+    alias AshEvents.Accounts.ArticleTag
+    alias AshEvents.Accounts.Tag
+
+    # Create a tag
+    tag =
+      Tag
+      |> Ash.Changeset.for_create(:create, %{name: "test-tag"})
+      |> Ash.create!(actor: %SystemActor{name: "system"})
+
+    # Create articles with tags
+    articles =
+      1..3
+      |> Enum.map(fn i ->
+        Article
+        |> Ash.Changeset.for_create(:create_with_tags, %{
+          title: "Article #{i}",
+          body: "Body #{i}",
+          tags: [%{id: tag.id}]
+        })
+        |> Ash.create!(actor: %SystemActor{name: "system"})
+      end)
+
+    # Verify article_tags were created
+    article_tags = ArticleTag |> Ash.read!()
+    assert Enum.count(article_tags) == 3
+
+    # Bulk soft-delete the articles with nested bulk operation to delete tags
+    # This tests the fix for original_params being nil in nested bulk operations
+    result =
+      articles
+      |> Ash.bulk_destroy!(:soft_destroy_with_tags, %{},
+        resource: Article,
+        return_errors?: true,
+        return_notifications?: true,
+        return_records?: true,
+        strategy: :stream,
+        actor: %SystemActor{name: "system"}
+      )
+
+    assert result.error_count == 0
+    assert Enum.count(result.records) == 3
+
+    # Verify articles are soft-deleted (deleted_at is set)
+    all_articles = Article |> Ash.read!()
+
+    Enum.each(all_articles, fn article ->
+      assert article.deleted_at != nil
+    end)
+
+    # Verify article_tags were hard deleted by the nested bulk operation
+    article_tags_after = ArticleTag |> Ash.read!()
+    assert article_tags_after == []
+
+    # Verify soft-delete events were created for articles
+    events =
+      EventLog
+      |> Ash.Query.filter(resource == ^Article and action == :soft_destroy_with_tags)
+      |> Ash.read!()
+
+    assert Enum.count(events) == 3
+  end
+
   test "single create without return_notifications? should work fine" do
     org =
       Accounts.Org

--- a/test/support/accounts/article.ex
+++ b/test/support/accounts/article.ex
@@ -67,6 +67,31 @@ defmodule AshEvents.Accounts.Article do
       change set_attribute(:deleted_at, &DateTime.utc_now/0)
     end
 
+    destroy :soft_destroy_with_tags do
+      require_atomic? false
+      soft? true
+      description "Soft delete an article and bulk destroy its article_tags"
+      accept []
+      change set_attribute(:deleted_at, &DateTime.utc_now/0)
+
+      # Nested bulk operation - delete article_tags
+      change fn changeset, _context ->
+        Ash.Changeset.after_action(changeset, fn _changeset, record ->
+          require Ash.Query
+
+          AshEvents.Accounts.ArticleTag
+          |> Ash.Query.filter(article_id == ^record.id)
+          |> Ash.bulk_destroy!(:destroy, %{},
+            authorize?: false,
+            return_errors?: true,
+            strategy: :stream
+          )
+
+          {:ok, record}
+        end)
+      end
+    end
+
     create :create_with_tags do
       accept [:id, :created_at, :updated_at, :title, :body]
       argument :tags, {:array, :map}, default: []


### PR DESCRIPTION
When using Ash.bulk_destroy/4 with a soft-delete action that has an after_action callback triggering a nested bulk operation, the call was crashing with a BadMapError because merged_ctx.original_params was nil.

This is the exact scenario used by AshJsonApi for DELETE requests (it uses Ash.bulk_destroy with strategy: [:atomic, :stream, :atomic_batches]),
and is common when soft-deleting a parent record that needs to cascade soft-delete to children.

The fix safely retrieves original_params from either the merged context or the changeset context, defaulting to an empty map.