### PR TITLE
fix: defer before_action?: true validations instead of running them eagerly

### DIFF
--- a/lib/events/replay_validation_wrapper.ex
+++ b/lib/events/replay_validation_wrapper.ex
@@ -57,9 +57,46 @@ defmodule AshEvents.Events.ReplayValidationWrapper do
         }
       end
     else
+      maybe_deferred_run_validation(
+        changeset,
+        validation,
+        validation_module,
+        validation_opts,
+        context,
+        custom_message
+      )
+    end
+  end
+
+  # before_action? validations need to stay in a before_action hook, otherwise
+  # they run during changeset construction (e.g. Ash.can?/2) and before any
+  # other before_action change. See Ash.Changeset.validate/5.
+  defp maybe_deferred_run_validation(
+         changeset,
+         validation,
+         validation_module,
+         validation_opts,
+         context,
+         custom_message
+       ) do
+    if before_action?(validation) do
+      Ash.Changeset.before_action(changeset, fn changeset ->
+        if only_when_valid?(validation) and not changeset.valid? do
+          changeset
+        else
+          run_validation(changeset, validation_module, validation_opts, context, custom_message)
+        end
+      end)
+    else
       run_validation(changeset, validation_module, validation_opts, context, custom_message)
     end
   end
+
+  defp before_action?(%Ash.Resource.Validation{before_action?: true}), do: true
+  defp before_action?(_validation), do: false
+
+  defp only_when_valid?(%Ash.Resource.Validation{only_when_valid?: true}), do: true
+  defp only_when_valid?(_validation), do: false
 
   defp run_validation(changeset, validation_module, validation_opts, context, custom_message) do
     case validation_module.init(validation_opts) do

--- a/test/ash_events/before_action_validation_test.exs
+++ b/test/ash_events/before_action_validation_test.exs
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2023 ash_events contributors <https://github.com/ash-project/ash_events/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshEvents.BeforeActionValidationTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias AshEvents.Accounts.Org
+
+  test "before_action? validations aren't run while building the changeset" do
+    # required_arg is omitted on purpose: the validation requires it, but since
+    # it's before_action? the changeset is still valid until the action runs.
+    changeset =
+      Ash.Changeset.for_create(Org, :create_with_before_action_validation, %{name: "Acme"})
+
+    assert changeset.valid?
+    assert changeset.before_action != []
+  end
+end

--- a/test/support/accounts/org.ex
+++ b/test/support/accounts/org.ex
@@ -53,6 +53,12 @@ defmodule AshEvents.Accounts.Org do
       argument :justification, :string, allow_nil?: false, constraints: [allow_empty?: true]
       validate attribute_equals(:active, false), message: "Organization is already active"
     end
+
+    create :create_with_before_action_validation do
+      accept [:id, :created_at, :updated_at, :name]
+      argument :required_arg, :string
+      validate present(:required_arg), before_action?: true
+    end
   end
 
   attributes do


### PR DESCRIPTION
## Problem

AshEvents wraps every validation on a tracked action in a change (`ReplayValidationWrapper`) so it can preserve custom messages and support replay. A change's `change/3` runs eagerly while the changeset is being built, whereas native Ash registers a `before_action?: true` validation inside a `before_action` hook (see `Ash.Changeset.validate/5`).

As a result, a `before_action?: true` validation on an event-tracked action loses its deferred semantics:

1. **`Ash.can?/2` breaks.** `Ash.can?({Resource, :create}, actor)` builds a changeset with empty input but never runs the action. The eagerly-run validation fires anyway, so a validation that depends on input only available at action time (e.g. it reads a required argument to query the DB) raises during `can?`. This makes it impossible to use `Ash.can?` to drive UI such as conditionally rendering a create button.
2. **Hook ordering.** The validation runs during construction, ahead of earlier `before_action` changes meant to populate the data it depends on.

## Fix

In `ReplayValidationWrapper`, when the wrapped validation is `before_action?: true` (and not during replay), defer it into an `Ash.Changeset.before_action/2` hook instead of running it inline, mirroring native Ash. `only_when_valid?` is honored inside the hook, and hooks are appended (the default) so ordering relative to other `before_action` changes is preserved.

Non-`before_action` validations and the replay path are unchanged.

## Tests

Adds a regression test with a `before_action?: true` validation on `AshEvents.Accounts.Org`. It builds a changeset omitting the required argument and asserts the changeset stays valid (validation deferred) and that a `before_action` hook was registered. Without the fix the validation runs during construction and the changeset is invalid; with it, the test passes.